### PR TITLE
Separate services and deployments

### DIFF
--- a/resources/docker/nginx/server.conf
+++ b/resources/docker/nginx/server.conf
@@ -13,7 +13,7 @@ server {
     }
 
     location ~ ^/index.php$ {
-        fastcgi_pass localhost:9000;
+        fastcgi_pass php7-service:9000;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME  $document_root$fastcgi_script_name;
         include       fastcgi_params;

--- a/resources/kubernetes/deployments/local-deployment.yaml
+++ b/resources/kubernetes/deployments/local-deployment.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: php7
-        image: rabellamy/php7
+        image: rabellamy/php7:0.1.0
         ports:
         - containerPort: 9000
         volumeMounts:
@@ -36,6 +36,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: rabellamy/nginx
+        image: rabellamy/nginx:0.1.0
         ports:
         - containerPort: 80

--- a/resources/kubernetes/deployments/local-deployment.yaml
+++ b/resources/kubernetes/deployments/local-deployment.yaml
@@ -1,19 +1,16 @@
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: local-deployment
+  name: php7-deployment
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: web
+        app: php7
     spec:
       containers:
-      - name: nginx
-        image: rabellamy/nginx
-        ports:
-        - containerPort: 80
       - name: php7
         image: rabellamy/php7
         ports:
@@ -25,3 +22,20 @@ spec:
       - name: src
         hostPath:
           path: /Users/scottrigby/development/NGINX-PHP-7-K8S-Deployment/src
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: rabellamy/nginx
+        ports:
+        - containerPort: 80

--- a/resources/kubernetes/services/local-service.yaml
+++ b/resources/kubernetes/services/local-service.yaml
@@ -14,7 +14,9 @@ spec:
     targetPort: 9000
   selector:
     app: php7
-  type: ClusterIP
+  # Minikube needs NodePort to work.
+  # type: ClusterIP
+  type: NodePort
   sessionAffinity: None
 ---
 kind: Service

--- a/resources/kubernetes/services/local-service.yaml
+++ b/resources/kubernetes/services/local-service.yaml
@@ -2,23 +2,35 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: local-service
+  name: php7-service
   namespace: default
   labels:
-    app: web
+    app: php7
+spec:
+  ports:
+  - name: listener
+    protocol: TCP
+    port: 9000
+    targetPort: 9000
+  selector:
+    app: php7
+  type: ClusterIP
+  sessionAffinity: None
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: nginx-service
+  namespace: default
+  labels:
+    app: nginx
 spec:
   ports:
   - name: http
     protocol: TCP
     port: 80
     targetPort: 80
-  - name: listener
-    protocol: TCP
-    port: 9000
-    targetPort: 9000
   selector:
-    app: web
+    app: nginx
   type: NodePort
   sessionAffinity: None
-status:
-  loadBalancer: {}


### PR DESCRIPTION
We already had NGINX and PHP 7 in separate containers, but in the same service and same deployment. 

One of the benefits of separating services is that we could scale one separately as needed, and this still keeps our example simple. 

Note we also versioned the images (built from the Dockerfiles and templates in `resources/docker`), so now using version `0.1.0` instead of :latest.